### PR TITLE
Implement State Overrides for Simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,16 @@ export type SimulationRequest = {
   gasLimit: number;
   value: string;
   blockNumber?: number; // if not specified, latest used,
+  stateOverrides?: Record<string, StateOverride>;
   formatTrace?: boolean;
+};
+
+export type StateOverride = {
+  balance?: string;
+  nonce?: number;
+  code?: string;
+  state?: Record<string, string>;
+  stateDiff?: Record<string, string>;
 };
 
 export type SimulationResponse = {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,16 +11,6 @@ pub struct ErrorMessage {
 }
 
 #[derive(Debug)]
-pub struct FromHexError;
-
-impl Reject for FromHexError {}
-
-#[derive(Debug)]
-pub struct FromDecStrError;
-
-impl Reject for FromDecStrError {}
-
-#[derive(Debug)]
 pub struct NoURLForChainIdError;
 
 impl Reject for NoURLForChainIdError {}
@@ -51,6 +41,11 @@ pub struct StateNotFound();
 impl Reject for StateNotFound {}
 
 #[derive(Debug)]
+pub struct OverrideError;
+
+impl Reject for OverrideError {}
+
+#[derive(Debug)]
 pub struct EvmError(pub Report);
 
 impl Reject for EvmError {}
@@ -65,12 +60,6 @@ pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> 
     } else if let Some(_e) = err.find::<StateNotFound>() {
         code = StatusCode::NOT_FOUND;
         message = "STATE_NOT_FOUND".to_string();
-    } else if let Some(FromHexError) = err.find() {
-        code = StatusCode::BAD_REQUEST;
-        message = "FROM_HEX_ERROR".to_string();
-    } else if let Some(FromDecStrError) = err.find() {
-        code = StatusCode::BAD_REQUEST;
-        message = "FROM_DEC_STR_ERROR".to_string();
     } else if let Some(NoURLForChainIdError) = err.find() {
         code = StatusCode::BAD_REQUEST;
         message = "CHAIN_ID_NOT_SUPPORTED".to_string();
@@ -86,6 +75,9 @@ pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> 
     } else if let Some(_e) = err.find::<InvalidBlockNumbersError>() {
         code = StatusCode::BAD_REQUEST;
         message = "INVALID_BLOCK_NUMBERS".to_string();
+    } else if let Some(_e) = err.find::<OverrideError>() {
+        code = StatusCode::INTERNAL_SERVER_ERROR;
+        message = "OVERRIDE_ERROR".to_string();
     } else if let Some(_e) = err.find::<EvmError>() {
         if _e.0.to_string().contains("CallGasCostMoreThanGasLimit") {
             code = StatusCode::BAD_REQUEST;

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -34,8 +34,8 @@ pub struct SimulationRequest {
     pub gas_limit: u64,
     pub value: Option<PermissiveUint>,
     pub block_number: Option<u64>,
-    pub format_trace: Option<bool>,
     pub state_overrides: Option<HashMap<Address, StateOverride>>,
+    pub format_trace: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -168,7 +168,7 @@ async fn post_simulate_state_overrides() {
         "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB": {
           "stateDiff": {
             "0xfca351f4d96129454cfc8ef7930b638ac71fea35eb69ee3b8d959496beb04a33":
-              "100000000000000000000000000000000000000"
+              "123456789012345678901234567890"
           }
         }
       }
@@ -186,10 +186,7 @@ async fn post_simulate_state_overrides() {
     let body: SimulationResponse = serde_json::from_slice(res.body()).unwrap();
     let result = U256::from_big_endian(&body.return_data);
 
-    assert_eq!(
-        result,
-        U256::from_dec_str("100000000000000000000000000000000000000").unwrap(),
-    );
+    assert_eq!(result.as_u128(), 123456789012345678901234567890);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -155,6 +155,44 @@ async fn post_simulate_zerox_swap() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn post_simulate_state_overrides() {
+    let filter = filter();
+
+    let json = serde_json::json!({
+      "chainId": 1,
+      "from": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+      "to": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+      "data": "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045",
+      "gasLimit": 5000000,
+      "stateOverrides": {
+        "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB": {
+          "stateDiff": {
+            "0xfca351f4d96129454cfc8ef7930b638ac71fea35eb69ee3b8d959496beb04a33":
+              "100000000000000000000000000000000000000"
+          }
+        }
+      }
+    });
+
+    let res = warp::test::request()
+        .method("POST")
+        .path("/simulate")
+        .json(&json)
+        .reply(&filter)
+        .await;
+
+    assert_eq!(res.status(), 200);
+
+    let body: SimulationResponse = serde_json::from_slice(res.body()).unwrap();
+    let result = U256::from_big_endian(&body.return_data);
+
+    assert_eq!(
+        result,
+        U256::from_dec_str("100000000000000000000000000000000000000").unwrap(),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn post_simulate_bundle_single_zerox_swap() {
     let filter = filter();
 


### PR DESCRIPTION
This PR adds support for state overrides to the simulator.

At first, I wanted to use some of the built-in state overriding methods to the `foundry_evm::Executor` (namely [`set_balance`](https://github.com/foundry-rs/foundry/blob/12ea9f61a344087989f884d2ab735893c77ea576/evm/src/executor/mod.rs#L171) and [`set_nonce`](https://github.com/foundry-rs/foundry/blob/12ea9f61a344087989f884d2ab735893c77ea576/evm/src/executor/mod.rs#L190)). The issue was that the `foundry_evm::Executor` does not expose APIs for overriding code or storage slots. If you use `foundry_evm::Executor::backend_mut`, you additionally get  [`foundry_evm::Backend::insert_account_info`](https://github.com/foundry-rs/foundry/blob/12ea9f61a344087989f884d2ab735893c77ea576/evm/src/executor/backend/mod.rs#L458), but since there is no direct mutable access to the underlying `revm::CacheDB` instance (it is [private unfortunately](https://github.com/foundry-rs/foundry/blob/12ea9f61a344087989f884d2ab735893c77ea576/evm/src/executor/backend/mod.rs#L654)) you still cannot override storage slots. In a slightly more recent version of `foundry_evm` (would require updating the version in `Cargo.toml` which felt a bit more delecate), they [added methods for manipulating account storage](https://github.com/foundry-rs/foundry/pull/5351) but there is still no way to completely override the storage for an account (when using `storageOverrides[address].state` and not `stateDiff`).

The solution is to use `revm::DatabaseCommit` implementation (since `Backend` is an `revm` database that implements this) and update the database as if a transaction happened.

### Test Plan

**Should I implement automated tests for this?**.

I did some (admittedly) not very complete manual testing locally:

<details><summary>Get <code>vitalik.eth</code>'s CoW Protocol token balance</summary>

```sh
curl -s http://localhost:8080/api/v1/simulate -H 'Content-Type: application/json' --data '@-' <<JSON | jq
{
  "chainId": 1,
  "from": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
  "to": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
  "data": "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045",
  "gasLimit": 500000,
  "value": "0",
  "blockNumber": 18175734
}
JSON
```

```json
{
  "simulationId": 1,
  "gasUsed": 23994,
  "blockNumber": 18175734,
  "success": true,
  "trace": [
    {
      "callType": "CALL",
      "from": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
      "to": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
      "value": "0x0"
    }
  ],
  "formattedTrace": null,
  "logs": [],
  "exitReason": "Return",
  "returnData": "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
}
```

</details>

<details><summary>Turn <code>vitalik.eth</code> into a CoW Protocol maxi</summary>

```sh
curl -s http://localhost:8080/api/v1/simulate -H 'Content-Type: application/json' --data '@-' <<JSON | jq
{
  "chainId": 1,
  "from": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
  "to": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
  "data": "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045",
  "gasLimit": 500000,
  "value": "0",
  "blockNumber": 18175734,
  "stateOverrides": {
    "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB": {
      "stateDiff": {
        "0xfca351f4d96129454cfc8ef7930b638ac71fea35eb69ee3b8d959496beb04a33":
          "100000000000000000000000000000000000000"
      }
    }
  }
}
JSON
```

```json
{
  "simulationId": 1,
  "gasUsed": 23994,
  "blockNumber": 18175734,
  "success": true,
  "trace": [
    {
      "callType": "CALL",
      "from": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
      "to": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
      "value": "0x0"
    }
  ],
  "formattedTrace": null,
  "logs": [],
  "exitReason": "Return",
  "returnData": "0x000000000000000000000000000000004b3b4ca85a86c47a098a224000000000"
}
```

</details>