### PR TITLE
Add Support for Specifying Access Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,15 @@ export type SimulationRequest = {
   data?: string;
   gasLimit: number;
   value: string;
+  accessList?: AccessListItem[];
   blockNumber?: number; // if not specified, latest used,
   stateOverrides?: Record<string, StateOverride>;
   formatTrace?: boolean;
+};
+
+export type AccessListItem = {
+  address: string;
+  storageKeys: string[];
 };
 
 export type StateOverride = {

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use ethers::abi::{Address, Hash, Uint};
 use ethers::core::types::Log;
+use ethers::types::transaction::eip2930::AccessList;
 use ethers::types::Bytes;
 use foundry_config::Chain;
 use foundry_evm::executor::{fork::CreateFork, Executor};
@@ -17,6 +18,16 @@ use revm::DatabaseCommit;
 
 use crate::errors::{EvmError, OverrideError};
 use crate::simulation::CallTrace;
+
+#[derive(Debug, Clone)]
+pub struct CallRawRequest {
+    pub from: Address,
+    pub to: Address,
+    pub value: Option<Uint>,
+    pub data: Option<Bytes>,
+    pub access_list: Option<AccessList>,
+    pub format_trace: bool,
+}
 
 #[derive(Debug, Clone)]
 pub struct CallRawResult {
@@ -119,28 +130,22 @@ impl Evm {
         }
     }
 
-    pub async fn call_raw(
-        &mut self,
-        from: Address,
-        to: Address,
-        value: Option<Uint>,
-        data: Option<Bytes>,
-        format_trace: bool,
-    ) -> Result<CallRawResult, EvmError> {
+    pub async fn call_raw(&mut self, call: CallRawRequest) -> Result<CallRawResult, EvmError> {
+        self.set_access_list(call.access_list);
         let res = self
             .executor
             .call_raw(
-                from,
-                to,
-                data.unwrap_or_default().0,
-                value.unwrap_or_default(),
+                call.from,
+                call.to,
+                call.data.unwrap_or_default().0,
+                call.value.unwrap_or_default(),
             )
             .map_err(|err| {
                 dbg!(&err);
                 EvmError(err)
             })?;
 
-        let formatted_trace = if format_trace {
+        let formatted_trace = if call.format_trace {
             let mut output = String::new();
             for trace in &mut res.traces.clone() {
                 if let Some(identifier) = &mut self.etherscan_identifier {
@@ -218,28 +223,25 @@ impl Evm {
 
     pub async fn call_raw_committing(
         &mut self,
-        from: Address,
-        to: Address,
-        value: Option<Uint>,
-        data: Option<Bytes>,
+        call: CallRawRequest,
         gas_limit: u64,
-        format_trace: bool,
     ) -> Result<CallRawResult, EvmError> {
         self.executor.set_gas_limit(gas_limit.into());
+        self.set_access_list(call.access_list);
         let res = self
             .executor
             .call_raw_committing(
-                from,
-                to,
-                data.unwrap_or_default().0,
-                value.unwrap_or_default(),
+                call.from,
+                call.to,
+                call.data.unwrap_or_default().0,
+                call.value.unwrap_or_default(),
             )
             .map_err(|err| {
                 dbg!(&err);
                 EvmError(err)
             })?;
 
-        let formatted_trace = if format_trace {
+        let formatted_trace = if call.format_trace {
             let mut output = String::new();
             for trace in &mut res.traces.clone() {
                 if let Some(identifier) = &mut self.etherscan_identifier {
@@ -285,5 +287,22 @@ impl Evm {
 
     pub fn get_chain_id(&self) -> Uint {
         self.executor.env().cfg.chain_id.into()
+    }
+
+    fn set_access_list(&mut self, access_list: Option<AccessList>) {
+        self.executor.env_mut().tx.access_list = access_list
+            .unwrap_or_default()
+            .0
+            .into_iter()
+            .map(|item| {
+                (
+                    h160_to_b160(item.address),
+                    item.storage_keys
+                        .into_iter()
+                        .map(|key| u256_to_ru256(Uint::from_big_endian(key.as_bytes())))
+                        .collect(),
+                )
+            })
+            .collect();
     }
 }


### PR DESCRIPTION
This PR adds support for specifying access lists to simulations. It is mostly straight forward, we overwrite the `foundry::Evm`'s `TxEnv` to additionally include a simulation's access list (just requires some type conversions as the `revm` crate uses slightly different types to `ethers`).

`call_raw_*` Functions now take a single `CallRawRequest` as the number of arguments were growing and hit Clippy's "too many arguments" lint.

### Manual Testing:

<details><summary>Run simulations with and without access lists and see different gas used amounts:</summary>

```
% curl -s http://localhost:8080/api/v1/simulate -H 'Content-Type: application/json' --data '@-' <<JSON | jq .gasUsed
{
  "chainId": 1,
  "from": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
  "to": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
  "data": "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045",
  "gasLimit": 50000,
  "value": "0",
  "blockNumber": 18175734,
  "accessList": [{ "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", "storageKeys": [] }]
}
JSON
26394

% curl -s http://localhost:8080/api/v1/simulate -H 'Content-Type: application/json' --data '@-' <<JSON | jq .gasUsed
{
  "chainId": 1,
  "from": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
  "to": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
  "data": "0x70a08231000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045",
  "gasLimit": 50000,
  "value": "0",
  "blockNumber": 18175734 
}                                                                                                
JSON
23994
```

</details>