### PR TITLE
if `FORK_URL` is defined, use that as url 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Example response:
 ```
 
 Notes:
-
+- `chainId` must be the same as the `chainId` of the `FORK_URL` environment variable, if defined. 
 - `blockNumber` can be omitted and the latest block will be used, however providing a `blockNumber` is recommended where possible to use the cache.
 
 ### POST /api/v1/simulate-bundle
@@ -82,7 +82,7 @@ Example response:
 
 Notes:
 
-- `chainId` must be the same in all transactions.
+- `chainId` must be the same in all transactions and it must match the `chainId` of `FORK_URL` environment variable, if defined. 
 - `blockNumber` can be included and incremented when a multi-block simulation is required, or omitted in all transactions to use latest.
 
 ### POST /api/v1/simulate-stateful
@@ -148,7 +148,7 @@ Example response:
 ```
 Notes:
 
-- `chainId` must be the same in all transactions.
+- `chainId` must be the same in all transactions and it must match the `chainId` of `FORK_URL` environment variable, if defined.
 - `blockNumber` can be included and incremented when a multi-block simulation is required, or omitted in all transactions to use latest.
 
 

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -227,9 +227,11 @@ async fn run(
 }
 
 pub async fn simulate(transaction: SimulationRequest, config: Config) -> Result<Json, Rejection> {
-    let fork_url = config
-        .fork_url
-        .unwrap_or(chain_id_to_fork_url(transaction.chain_id)?);
+    let fork_url = if let Some(url) = config.fork_url {
+        url
+    } else {
+        chain_id_to_fork_url(transaction.chain_id)?
+    };
     let mut evm = Evm::new(
         None,
         fork_url,
@@ -238,6 +240,10 @@ pub async fn simulate(transaction: SimulationRequest, config: Config) -> Result<
         true,
         config.etherscan_key,
     );
+
+    // println!("EVM Config: {:?}", evm);
+
+    log::debug!("Current Chain ID: {}", evm.get_chain_id());
 
     if evm.get_chain_id() != Uint::from(transaction.chain_id) {
         return Err(warp::reject::custom(IncorrectChainIdError()));
@@ -262,9 +268,11 @@ pub async fn simulate_bundle(
     let first_block_number = transactions[0].block_number;
     let first_block_timestamp = transactions[0].block_timestamp;
 
-    let fork_url = config
-        .fork_url
-        .unwrap_or(chain_id_to_fork_url(first_chain_id)?);
+    let fork_url = if let Some(url) = config.fork_url {
+        url
+    } else {
+        chain_id_to_fork_url(first_chain_id)?
+    };
     let mut evm = Evm::new(
         None,
         fork_url,
@@ -315,9 +323,11 @@ pub async fn simulate_stateful_new(
     config: Config,
     state: Arc<SharedSimulationState>,
 ) -> Result<Json, Rejection> {
-    let fork_url = config
-        .fork_url
-        .unwrap_or(chain_id_to_fork_url(stateful_simulation_request.chain_id)?);
+    let fork_url = if let Some(url) = config.fork_url {
+        url
+    } else {
+        chain_id_to_fork_url(stateful_simulation_request.chain_id)?
+    };
     let mut evm = Evm::new(
         None,
         fork_url,

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -241,10 +241,6 @@ pub async fn simulate(transaction: SimulationRequest, config: Config) -> Result<
         config.etherscan_key,
     );
 
-    // println!("EVM Config: {:?}", evm);
-
-    log::debug!("Current Chain ID: {}", evm.get_chain_id());
-
     if evm.get_chain_id() != Uint::from(transaction.chain_id) {
         return Err(warp::reject::custom(IncorrectChainIdError()));
     }


### PR DESCRIPTION
Hey Team,

I've had some issues running this by default for Base, since no matter if the `FORK_URL` was defined, it'd simply get `CHAIN_ID_NOT_SUPPORTED` error as `chain_id_to_fork_url` function does not have Base statically added.

I'm proposing this fix, since when passing `FORK_URL` in, you're already constrained to use that chain for simulation, else you get `INCORRECT_CHAIN_ID`, so it just allows the usage of more than the static chains. 


Best, 
8x4